### PR TITLE
[crystal][client] support configure method with block

### DIFF
--- a/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
@@ -119,6 +119,7 @@ module {{moduleName}}
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     #property params_encoding : String?
 
+    # Create a new `Configuration`.
     def initialize
       @scheme = "{{scheme}}"
       @host = "{{host}}{{#port}}:{{{.}}}{{/port}}"
@@ -141,9 +142,19 @@ module {{moduleName}}
       @password = nil
       @access_token = nil
       @temp_folder_path = nil
+    end
 
-      # TODO revise below to support block
-      #yield(self) if block_given?
+    # Create a new `Configuration` with block.
+    #
+    # ```
+    # config = Petstore::Configuration.new do |config|
+    #   config.username = "xxx"
+    #   config.password = "xxx"
+    # end
+    # ```
+    def initialize
+      initialize
+      yield self
     end
 
     # The default Configuration object.

--- a/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/configuration.mustache
@@ -162,8 +162,9 @@ module {{moduleName}}
       @@default ||= Configuration.new
     end
 
+    # Configure object with block.
     def configure
-      yield(self) if block_given?
+      yield self
     end
 
     def scheme=(scheme)

--- a/modules/openapi-generator/src/main/resources/crystal/shard_name.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/shard_name.mustache
@@ -9,18 +9,21 @@ module {{moduleName}}
 
   VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
 
+  # Return the default `Configuration` object.
+  def self.configure
+    Configuration.default
+  end
+
   # Customize default settings for the SDK using block.
-  #   {{moduleName}}.configure do |config|
-  #     config.username = "xxx"
-  #     config.password = "xxx"
-  #   end
-  # If no block given, return the default Configuration object.
-  def configure
-    if block_given?
-      yield(Configuration.default)
-    else
-      Configuration.default
-    end
+  #
+  # ```
+  # {{moduleName}}.configure do |config|
+  #   config.username = "xxx"
+  #   config.password = "xxx"
+  # end
+  # ```
+  def self.configure
+    yield Configuration.default
   end
 end
 

--- a/samples/client/petstore/crystal/spec/configuration_spec.cr
+++ b/samples/client/petstore/crystal/spec/configuration_spec.cr
@@ -12,4 +12,15 @@ describe Petstore::Configuration do
       end
     end
   end
+
+  describe "#configure" do
+    it "works" do
+      config = Petstore::Configuration.new
+      config.configure do |config|
+        config.username = "xxx"
+      end
+
+      config.username.should eq "xxx"
+    end
+  end
 end

--- a/samples/client/petstore/crystal/spec/configuration_spec.cr
+++ b/samples/client/petstore/crystal/spec/configuration_spec.cr
@@ -1,0 +1,15 @@
+require "./spec_helper"
+
+describe Petstore::Configuration do
+  describe "#initialize" do
+    context "with block" do
+      it "works" do
+        config = Petstore::Configuration.new do |config|
+          config.username = "xxx"
+        end
+
+        config.username.should eq "xxx"
+      end
+    end
+  end
+end

--- a/samples/client/petstore/crystal/spec/petstore_spec.cr
+++ b/samples/client/petstore/crystal/spec/petstore_spec.cr
@@ -1,0 +1,19 @@
+require "./spec_helper"
+
+describe Petstore do
+  describe "#configure" do
+    it "works" do
+      Petstore.configure do |config|
+        config.username = "xxx"
+      end
+
+      config = Petstore.configure
+
+      config.should eq Petstore::Configuration.default
+      config.username.should eq "xxx"
+
+      # Clean up
+      Petstore::Configuration.default.username = nil
+    end
+  end
+end

--- a/samples/client/petstore/crystal/src/petstore.cr
+++ b/samples/client/petstore/crystal/src/petstore.cr
@@ -17,18 +17,21 @@ module Petstore
 
   VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
 
+  # Return the default `Configuration` object.
+  def self.configure
+    Configuration.default
+  end
+
   # Customize default settings for the SDK using block.
-  #   Petstore.configure do |config|
-  #     config.username = "xxx"
-  #     config.password = "xxx"
-  #   end
-  # If no block given, return the default Configuration object.
-  def configure
-    if block_given?
-      yield(Configuration.default)
-    else
-      Configuration.default
-    end
+  #
+  # ```
+  # Petstore.configure do |config|
+  #   config.username = "xxx"
+  #   config.password = "xxx"
+  # end
+  # ```
+  def self.configure
+    yield Configuration.default
   end
 end
 

--- a/samples/client/petstore/crystal/src/petstore/configuration.cr
+++ b/samples/client/petstore/crystal/src/petstore/configuration.cr
@@ -170,8 +170,9 @@ module Petstore
       @@default ||= Configuration.new
     end
 
+    # Configure object with block.
     def configure
-      yield(self) if block_given?
+      yield self
     end
 
     def scheme=(scheme)

--- a/samples/client/petstore/crystal/src/petstore/configuration.cr
+++ b/samples/client/petstore/crystal/src/petstore/configuration.cr
@@ -127,6 +127,7 @@ module Petstore
     # https://github.com/typhoeus/ethon/blob/master/lib/ethon/easy/queryable.rb#L96
     #property params_encoding : String?
 
+    # Create a new `Configuration`.
     def initialize
       @scheme = "http"
       @host = "petstore.swagger.io"
@@ -149,9 +150,19 @@ module Petstore
       @password = nil
       @access_token = nil
       @temp_folder_path = nil
+    end
 
-      # TODO revise below to support block
-      #yield(self) if block_given?
+    # Create a new `Configuration` with block.
+    #
+    # ```
+    # config = Petstore::Configuration.new do |config|
+    #   config.username = "xxx"
+    #   config.password = "xxx"
+    # end
+    # ```
+    def initialize
+      initialize
+      yield self
     end
 
     # The default Configuration object.


### PR DESCRIPTION
Support `configure` method with block that looks like:

```crystal
Petstore.configure do |config|
  config.username = "xxx"
  config.password = "xxx"
end

# And likewise...

Petstore::Configuration.new do |config|
  ...
end

config = Petstore::Configuration.new
config.configure do |config|
  ...
end
```

Note:
`block_given?` is not supported in Crystal currently.
https://github.com/crystal-lang/crystal/issues/1013

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
